### PR TITLE
Align columns in overview screen

### DIFF
--- a/src/gui/overview_form.cc
+++ b/src/gui/overview_form.cc
@@ -76,7 +76,7 @@ void OverviewForm::refreshLastBackupsOverview()
 	qDebug() << "OverviewForm::refreshLastBackupsOverview()";
 	Settings* settings = Settings::getInstance();
 	QStringList fieldnames_status;
-	fieldnames_status << "labelIconStatusLastBackup_%1" << "labelStatusLastBackup_%1" << "labelDateLastBackup_%1" << "labelWeekdayLastBackup_%1";
+	fieldnames_status << "labelIconStatusLastBackup_%1" << "labelStatusLastBackup_%1" << "labelDayLastBackup_%1" << "labelDateLastBackup_%1" << "labelTimeLastBackup_%1";
 	QImage img;
 
 	// fill map with a pixmap for each status
@@ -97,15 +97,22 @@ void OverviewForm::refreshLastBackupsOverview()
 		lab_icon->setHidden( isHidden );
 		QLabel* lab_status = this->findChild<QLabel *>( fieldnames_status[1].arg( i ) );
 		lab_status->setHidden( isHidden );
-		QLabel* lab_date = this->findChild<QLabel *>( fieldnames_status[2].arg( i ) );
+		QLabel* lab_day = this->findChild<QLabel *>( fieldnames_status[2].arg( i ) );
+		lab_day->setHidden( isHidden );
+		QLabel* lab_date = this->findChild<QLabel *>( fieldnames_status[3].arg( i ) );
 		lab_date->setHidden( isHidden );
+		QLabel* lab_time = this->findChild<QLabel *>( fieldnames_status[4].arg( i ) );
+		lab_time->setHidden( isHidden );
+
 		if ( !isHidden )
 		{
 			BackupTask lastBackup = lastBackups.at( i );
 			ConstUtils::StatusEnum status = lastBackup.getStatus();
 			lab_icon->setPixmap( status_pixmap.value( status ) );
 			lab_status->setText( lastBackup.getStatusText() );
-			lab_date->setText( lastBackup.getDateTime().toString("dddd,\tdd.MM.yyyy  hh:mm") );
+			lab_day->setText( lastBackup.getDateTime().toString("dddd") );
+			lab_date->setText( lastBackup.getDateTime().toString("dd.MM.yyyy") );
+			lab_time->setText( lastBackup.getDateTime().toString("hh:mm") );
 		}
 	}
 }
@@ -118,12 +125,43 @@ void OverviewForm::refreshScheduleOverview()
 	if ( myTask.getType() != ScheduleRule::NEVER )
 	{
 		this->labelNextBackup->setText( QObject::tr( "Scheduled" ) );
-		this->labelDateNextBackup->setText( myTask.toString() );
+
+		// Get the next execution string which will be of format:
+		// weekday,\tdd.MM.yyyy   hh:mm
+		QString next_task = myTask.toString();
+
+		// Prepare the regex to extract weekday, date and time from the task
+		// string
+		QString next_weekday;
+        QString next_date;
+        QString next_time;
+        QRegExp regex("(\\w*),\t(\\d{2}.\\d{2}.\\d{4})\\s*(\\d{2}:\\d{2})");
+
+        // Parse the next_task in order to extract weekday, date and time and
+        int pos = regex.indexIn( next_task );
+        if (pos > -1) {
+            next_weekday = regex.cap(1);
+            next_date = regex.cap(2);
+            next_time = regex.cap(3);
+        } else
+        {
+            next_date = "";
+            next_time = "";
+            next_weekday = "Not found";
+        }
+
+        // Set the corresponding label text
+		this->labelDateNextBackup->setText( next_date );
+		this->labelTimeNextBackup->setText( next_time );
+		this->labelDayNextBackup->setText( next_weekday );
+
 	}
 	else
 	{
 		this->labelNextBackup->setText( QObject::tr( "Not scheduled" ) );
 		this->labelDateNextBackup->setText( "" );
+		this->labelDayNextBackup->setText( "" );
+		this->labelTimeNextBackup->setText( "" );
 	}
 }
 

--- a/src/gui/overview_form.ui
+++ b/src/gui/overview_form.ui
@@ -459,15 +459,41 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelDateLastBackup_0">
+         <widget class="QLabel" name="labelDayLastBackup_0">
           <property name="minimumSize">
            <size>
-            <width>70</width>
+            <width>85</width>
             <height>0</height>
            </size>
           </property>
           <property name="text">
-           <string>Freitag, 10.03.2011  12:34</string>
+           <string>Freitag</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelDateLastBackup_0">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>10.03.2011</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelTimeLastBackup_0">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>12:34</string>
           </property>
          </widget>
         </item>
@@ -527,15 +553,41 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelDateLastBackup_1">
+         <widget class="QLabel" name="labelDayLastBackup_1">
           <property name="minimumSize">
            <size>
-            <width>70</width>
+            <width>85</width>
             <height>0</height>
            </size>
           </property>
           <property name="text">
-           <string>Donnerstag, 10.03.2011  12:34</string>
+           <string>Donnerstag</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelDateLastBackup_1">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>09.03.2011</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelTimeLastBackup_1">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>12:34</string>
           </property>
          </widget>
         </item>
@@ -595,15 +647,41 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelDateLastBackup_2">
+         <widget class="QLabel" name="labelDayLastBackup_2">
           <property name="minimumSize">
            <size>
-            <width>70</width>
+            <width>85</width>
             <height>0</height>
            </size>
           </property>
           <property name="text">
-           <string>Freitag, 10.03.2011  12:34</string>
+           <string>Mittwoch</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelDateLastBackup_2">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>08.03.2011</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelTimeLastBackup_2">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>12:34</string>
           </property>
          </widget>
         </item>
@@ -663,15 +741,41 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelDateLastBackup_3">
+         <widget class="QLabel" name="labelDayLastBackup_3">
           <property name="minimumSize">
            <size>
-            <width>70</width>
+            <width>85</width>
             <height>0</height>
            </size>
           </property>
           <property name="text">
-           <string>Freitag, 10.03.2011  12:34</string>
+           <string>Dienstag</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelDateLastBackup_3">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>07.03.2011</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelTimeLastBackup_3">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>12:34</string>
           </property>
          </widget>
         </item>
@@ -731,15 +835,41 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelDateLastBackup_4">
+         <widget class="QLabel" name="labelDayLastBackup_4">
           <property name="minimumSize">
            <size>
-            <width>70</width>
+            <width>85</width>
             <height>0</height>
            </size>
           </property>
           <property name="text">
-           <string>Freitag, 10.03.2011  12:34</string>
+           <string>Montag</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelDateLastBackup_4">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>06.03.2011</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelTimeLastBackup_4">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>12:34</string>
           </property>
          </widget>
         </item>
@@ -813,9 +943,41 @@ Next Backup</string>
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelDateNextBackup">
+         <widget class="QLabel" name="labelDayNextBackup">
+          <property name="minimumSize">
+           <size>
+            <width>85</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="text">
-           <string>Freitag, 04.06.2012  23:05</string>
+           <string>Samstag</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelDateNextBackup">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>11.03.2011</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelTimeNextBackup">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>12.34</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The columns in the backup overview screen are now aligned. This fixes #9
